### PR TITLE
지나간날짜시간관련 기능추가

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -55,15 +55,15 @@ function App() {
             <SafeAreaProvider>
               <NavigationContainer>
                 <Stack.Navigator>
-                  {userState.isLogIn ? (
+                  {!userState.isLogIn ? (
                     <>
+                      <Stack.Screen name="DocScheme" component={DocScheme} />
                       <Stack.Screen
                         name="Mains"
                         component={Mains}
                         options={{headerShown: false}}
                       />
                       <Stack.Screen name="DocList" component={DocList} />
-                      <Stack.Screen name="DocScheme" component={DocScheme} />
                       <Stack.Screen name="MakeREZ" component={MakeREZ} />
                       <Stack.Screen
                         name="REZSubmit"

--- a/App.tsx
+++ b/App.tsx
@@ -55,15 +55,15 @@ function App() {
             <SafeAreaProvider>
               <NavigationContainer>
                 <Stack.Navigator>
-                  {!userState.isLogIn ? (
+                  {userState.isLogIn ? (
                     <>
-                      <Stack.Screen name="DocScheme" component={DocScheme} />
                       <Stack.Screen
                         name="Mains"
                         component={Mains}
                         options={{headerShown: false}}
                       />
                       <Stack.Screen name="DocList" component={DocList} />
+                      <Stack.Screen name="DocScheme" component={DocScheme} />
                       <Stack.Screen name="MakeREZ" component={MakeREZ} />
                       <Stack.Screen
                         name="REZSubmit"

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -1,4 +1,4 @@
-import React, {useContext} from 'react';
+import React, {useCallback, useContext} from 'react';
 import styled from 'styled-components/native';
 import CalendarButton from '@components/CalendarButton';
 import {NewDate, CalendarProps} from '~/src/types/type';
@@ -7,18 +7,21 @@ import {SelectContext} from '../ReservationContext';
 function Calendar({calendarDate, weeklength, dayoff, today}: CalendarProps) {
   const {selectDate} = useContext(SelectContext);
 
+  const isDayValid = useCallback((date: NewDate) => {
+    return (
+      date.year < today.year ||
+      date.month < today.month ||
+      date.date < today.date
+    );
+  }, []);
+
   return (
     <CalendarWrapper>
       <FirstWeek>
         {calendarDate.slice(0, 7).map((date: NewDate, idx: number) => (
           <CalendarButton
             key={idx}
-            isDayOff={
-              date.year < today.year ||
-              date.month < today.month ||
-              date.date < today.date ||
-              dayoff.includes(date.date.toString())
-            }
+            isDayOff={isDayValid(date) || dayoff.includes(date.date.toString())}
             isChecked={selectDate.date !== 0 && date.date === selectDate.date}
             dateInfo={date}>
             {date.date}

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -32,12 +32,7 @@ function Calendar({calendarDate, weeklength, dayoff, today}: CalendarProps) {
         {calendarDate.slice(7, 14).map((date: NewDate, idx: number) => (
           <CalendarButton
             key={idx}
-            isDayOff={
-              date.year < today.year ||
-              date.month < today.month ||
-              date.date < today.date ||
-              dayoff.includes(date.date.toString())
-            }
+            isDayOff={isDayValid(date) || dayoff.includes(date.date.toString())}
             isChecked={selectDate.date !== 0 && date.date === selectDate.date}
             dateInfo={date}>
             {date.date}
@@ -48,12 +43,7 @@ function Calendar({calendarDate, weeklength, dayoff, today}: CalendarProps) {
         {calendarDate.slice(14, 21).map((date: NewDate, idx: number) => (
           <CalendarButton
             key={idx}
-            isDayOff={
-              date.year < today.year ||
-              date.month < today.month ||
-              date.date < today.date ||
-              dayoff.includes(date.date.toString())
-            }
+            isDayOff={isDayValid(date) || dayoff.includes(date.date.toString())}
             isChecked={selectDate.date !== 0 && date.date === selectDate.date}
             dateInfo={date}>
             {date.date}
@@ -64,12 +54,7 @@ function Calendar({calendarDate, weeklength, dayoff, today}: CalendarProps) {
         {calendarDate.slice(21, 28).map((date: NewDate, idx: number) => (
           <CalendarButton
             key={idx}
-            isDayOff={
-              date.year < today.year ||
-              date.month < today.month ||
-              date.date < today.date ||
-              dayoff.includes(date.date.toString())
-            }
+            isDayOff={isDayValid(date) || dayoff.includes(date.date.toString())}
             isChecked={selectDate.date !== 0 && date.date === selectDate.date}
             dateInfo={date}>
             {date.date}
@@ -83,10 +68,7 @@ function Calendar({calendarDate, weeklength, dayoff, today}: CalendarProps) {
               <CalendarButton
                 key={idx}
                 isDayOff={
-                  date.year < today.year ||
-                  date.month < today.month ||
-                  date.date < today.date ||
-                  dayoff.includes(date.date.toString())
+                  isDayValid(date) || dayoff.includes(date.date.toString())
                 }
                 isChecked={
                   selectDate.date !== 0 && date.date === selectDate.date
@@ -102,10 +84,7 @@ function Calendar({calendarDate, weeklength, dayoff, today}: CalendarProps) {
                 <CalendarButton
                   key={idx}
                   isDayOff={
-                    date.year < today.year ||
-                    date.month < today.month ||
-                    date.date < today.date ||
-                    dayoff.includes(date.date.toString())
+                    isDayValid(date) || dayoff.includes(date.date.toString())
                   }
                   isChecked={
                     selectDate.date !== 0 && date.date === selectDate.date

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -9,9 +9,8 @@ function Calendar({calendarDate, weeklength, dayoff, today}: CalendarProps) {
 
   const isDayValid = useCallback((date: NewDate) => {
     return (
-      date.year < today.year ||
-      date.month < today.month ||
-      date.date < today.date
+      new Date(date.year, date.month, date.date) <
+      new Date(today.year, today.month, today.date)
     );
   }, []);
 

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -4,7 +4,7 @@ import CalendarButton from '@components/CalendarButton';
 import {NewDate, CalendarProps} from '~/src/types/type';
 import {SelectContext} from '../ReservationContext';
 
-function Calendar({calendarDate, weeklength, dayoff}: CalendarProps) {
+function Calendar({calendarDate, weeklength, dayoff, today}: CalendarProps) {
   const {selectDate} = useContext(SelectContext);
 
   return (
@@ -13,7 +13,12 @@ function Calendar({calendarDate, weeklength, dayoff}: CalendarProps) {
         {calendarDate.slice(0, 7).map((date: NewDate, idx: number) => (
           <CalendarButton
             key={idx}
-            isDayOff={dayoff.includes(date.date.toString())}
+            isDayOff={
+              date.year < today.year ||
+              date.month < today.month ||
+              date.date < today.date ||
+              dayoff.includes(date.date.toString())
+            }
             isChecked={selectDate.date !== 0 && date.date === selectDate.date}
             dateInfo={date}>
             {date.date}
@@ -24,7 +29,12 @@ function Calendar({calendarDate, weeklength, dayoff}: CalendarProps) {
         {calendarDate.slice(7, 14).map((date: NewDate, idx: number) => (
           <CalendarButton
             key={idx}
-            isDayOff={dayoff.includes(date.date.toString())}
+            isDayOff={
+              date.year < today.year ||
+              date.month < today.month ||
+              date.date < today.date ||
+              dayoff.includes(date.date.toString())
+            }
             isChecked={selectDate.date !== 0 && date.date === selectDate.date}
             dateInfo={date}>
             {date.date}
@@ -35,7 +45,12 @@ function Calendar({calendarDate, weeklength, dayoff}: CalendarProps) {
         {calendarDate.slice(14, 21).map((date: NewDate, idx: number) => (
           <CalendarButton
             key={idx}
-            isDayOff={dayoff.includes(date.date.toString())}
+            isDayOff={
+              date.year < today.year ||
+              date.month < today.month ||
+              date.date < today.date ||
+              dayoff.includes(date.date.toString())
+            }
             isChecked={selectDate.date !== 0 && date.date === selectDate.date}
             dateInfo={date}>
             {date.date}
@@ -46,7 +61,12 @@ function Calendar({calendarDate, weeklength, dayoff}: CalendarProps) {
         {calendarDate.slice(21, 28).map((date: NewDate, idx: number) => (
           <CalendarButton
             key={idx}
-            isDayOff={dayoff.includes(date.date.toString())}
+            isDayOff={
+              date.year < today.year ||
+              date.month < today.month ||
+              date.date < today.date ||
+              dayoff.includes(date.date.toString())
+            }
             isChecked={selectDate.date !== 0 && date.date === selectDate.date}
             dateInfo={date}>
             {date.date}
@@ -59,7 +79,12 @@ function Calendar({calendarDate, weeklength, dayoff}: CalendarProps) {
             {calendarDate.slice(28, 35).map((date: NewDate, idx: number) => (
               <CalendarButton
                 key={idx}
-                isDayOff={dayoff.includes(date.date.toString())}
+                isDayOff={
+                  date.year < today.year ||
+                  date.month < today.month ||
+                  date.date < today.date ||
+                  dayoff.includes(date.date.toString())
+                }
                 isChecked={
                   selectDate.date !== 0 && date.date === selectDate.date
                 }
@@ -73,7 +98,12 @@ function Calendar({calendarDate, weeklength, dayoff}: CalendarProps) {
               {calendarDate.slice(35, 42).map((date: NewDate, idx: number) => (
                 <CalendarButton
                   key={idx}
-                  isDayOff={dayoff.includes(date.date.toString())}
+                  isDayOff={
+                    date.year < today.year ||
+                    date.month < today.month ||
+                    date.date < today.date ||
+                    dayoff.includes(date.date.toString())
+                  }
                   isChecked={
                     selectDate.date !== 0 && date.date === selectDate.date
                   }

--- a/src/screens/DocScheme/DocScheme.tsx
+++ b/src/screens/DocScheme/DocScheme.tsx
@@ -22,15 +22,15 @@ const DAYS: string[] = ['일', '월', '화', '수', '목', '금', '토'];
 const TODAY = new Date();
 const DAYOFF: string[] = ['1', '4', '6', '14', '16', '20', '22', '24', '25'];
 const TIMES: TIMESProp[] = [
-  {id: '10:00'},
-  {id: '11:00'},
-  {id: '12:00'},
-  {id: '13:00'},
+  {id: '05:20'},
+  {id: '06:50'},
+  {id: '07:00'},
+  {id: '12:12'},
   {id: '14:00'},
   {id: '15:00'},
-  {id: '16:00'},
+  {id: '16:50'},
   {id: '17:00'},
-  {id: '18:00'},
+  {id: '18:55'},
   {id: '19:00'},
   {id: '20:00'},
   {id: '21:00'},
@@ -71,7 +71,7 @@ function DocScheme({navigation}: DocSchemeNavigationProps) {
     return {year, month, date, day, time: ''};
   };
 
-  const getToday: NewDate = useMemo(() => getNewDate(TODAY), []);
+  const today: NewDate = useMemo(() => getNewDate(TODAY), []);
 
   const getAlldate = () => {
     const selectFirstDate = getNewDate(new Date(date.year, date.month - 1, 1));
@@ -151,12 +151,19 @@ function DocScheme({navigation}: DocSchemeNavigationProps) {
 
   const isTimeValid = useCallback(
     (item: TIMESProp) => {
-      const LimitHours: number = TODAY.getHours() + 1;
-      const LimitMinutes: number = TODAY.getMinutes();
+      const limitHours: number = TODAY.getHours() + 1;
+      const limitMinutes: number = TODAY.getMinutes();
+      const timetableHours: number = Number(item.id.split(':')[0]);
+      const timetableMinutes: number = Number(item.id.split(':')[1]);
       return (
-        Number(item.id.split(':')[0]) < LimitHours ||
-        (Number(item.id.split(':')[0]) === LimitHours &&
-          Number(item.id.split(':')[1]) <= LimitMinutes)
+        new Date(
+          today.year,
+          today.month,
+          today.date,
+          timetableHours,
+          timetableMinutes,
+        ) <=
+        new Date(today.year, today.month, today.date, limitHours, limitMinutes)
       );
     },
     [date],
@@ -166,13 +173,13 @@ function DocScheme({navigation}: DocSchemeNavigationProps) {
     item.id ? (
       <TimeButton
         disabled={
-          (selectDate.date === getToday.date && isTimeValid(item)) ||
+          (selectDate.date === today.date && isTimeValid(item)) ||
           FULL.includes(item.id)
         }
         onPress={() => goMakeREZ(item.id)}>
         <ButtonText
           disabled={
-            (selectDate.date === getToday.date && isTimeValid(item)) ||
+            (selectDate.date === today.date && isTimeValid(item)) ||
             FULL.includes(item.id)
           }>
           {item.id}
@@ -218,7 +225,7 @@ function DocScheme({navigation}: DocSchemeNavigationProps) {
           dayoff={DAYOFF}
           weeklength={calendarDate.length}
           calendarDate={calendarDate}
-          today={getToday}
+          today={today}
         />
       </SchemeWrapper>
       <TimeTable isShow={selectDate.date !== 0}>

--- a/src/screens/DocScheme/DocScheme.tsx
+++ b/src/screens/DocScheme/DocScheme.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useEffect, useContext} from 'react';
+import React, {useState, useEffect, useContext, useMemo} from 'react';
 import {FlatList} from 'react-native';
 import styled, {css} from 'styled-components/native';
 import {NewDate} from '~/src/types/type';
@@ -28,8 +28,8 @@ const TIMES: IdType[] = [
   {id: '19:00'},
   {id: '20:00'},
   {id: '21:00'},
-  {id: '22:00'},
-  {id: '23:00'},
+  {id: '21:30'},
+  {id: '21:35'},
 ];
 
 const FULL: string[] = ['10:00', '11:00', '12:00'];
@@ -64,6 +64,13 @@ function DocScheme({navigation}: DocSchemeNavigationProps) {
 
     return {year, month, date, day, time: ''};
   };
+
+  const getToday: NewDate = useMemo(() => getNewDate(TODAY), []);
+  const getLimitTime = useMemo(() => {
+    const hours = TODAY.getHours() + 1;
+    const minutes = TODAY.getMinutes();
+    return {hours, minutes};
+  }, []);
 
   const getAlldate = () => {
     const selectFirstDate = getNewDate(new Date(date.year, date.month - 1, 1));
@@ -144,9 +151,26 @@ function DocScheme({navigation}: DocSchemeNavigationProps) {
   const renderItem = ({item}: {item: IdType}) =>
     item.id ? (
       <TimeButton
-        disabled={FULL.includes(item.id)}
+        disabled={
+          (selectDate.date === getToday.date &&
+            Number(item.id.split(':')[0]) < getLimitTime.hours) ||
+          Number(item.id.split(':')[0]) === getLimitTime.hours
+            ? Number(item.id.split(':')[1]) <= getLimitTime.minutes
+            : Number(item.id.split(':')[1]) > getLimitTime.minutes ||
+              FULL.includes(item.id)
+        }
         onPress={() => goMakeREZ(item.id)}>
-        <ButtonText disabled={FULL.includes(item.id)}>{item.id}</ButtonText>
+        <ButtonText
+          disabled={
+            (selectDate.date === getToday.date &&
+              Number(item.id.split(':')[0]) < getLimitTime.hours) ||
+            Number(item.id.split(':')[0]) === getLimitTime.hours
+              ? Number(item.id.split(':')[1]) <= getLimitTime.minutes
+              : Number(item.id.split(':')[1]) > getLimitTime.minutes ||
+                FULL.includes(item.id)
+          }>
+          {item.id}
+        </ButtonText>
       </TimeButton>
     ) : (
       <HiddenButton disabled></HiddenButton>
@@ -188,6 +212,7 @@ function DocScheme({navigation}: DocSchemeNavigationProps) {
           dayoff={DAYOFF}
           weeklength={calendarDate.length}
           calendarDate={calendarDate}
+          today={getToday}
         />
       </SchemeWrapper>
       <TimeTable isShow={selectDate.date !== 0}>

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -89,6 +89,7 @@ export interface CalendarProps {
   calendarDate: NewDate[];
   weeklength: number;
   dayoff: string[];
+  today: NewDate;
 }
 
 export interface CalBtnProps {


### PR DESCRIPTION
## :: 최근 작업 주제
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
<br />

## :: 구현 목표 

달력과 timetable에서 지나간 시간 및 날짜 관련하여 선택이 되지 않도록 구현하였습니다.
시간같은 경우는 정해진 시간으로부터 1시간 전까지만 선택이 가능하도록 하였습니다.


<br />

## :: 세부 내용

지나간 날짜관련 : DocScheme 에서 오늘 날짜에 대한 데이터 (year,month,date)를 달력을 만들어주는 컴포넌트에 내려준 후에, 만들어진 달력의 날짜와 오늘날짜를 비교하여, 생성된달력의 연도,월,일을 현재날짜와 각각 비교하여 현재 날짜보다 작은 경우에는 disable 속성이 되도록 구현하였습니다(지나간 날짜를 비교 한 후에는, 해당 의사의 dayOff 날짜와 비교하여 해당하면 disable이 되도록 하였습니다)

지나간 시간관련 : 현재 시간데이터를 가져오는 변수를 선언하여, 시간과 분의 데이터를 가져온 후에, 시간에 +1을 추가하여 LimitTime 변수를 선언해 줍니다. 그리고 난 후에 timetable을 생성시 사용되는 시간 String을 : 기준으로 시간과 분으로 나누어서 시간은 작을경우 무조건 disable 속성을 선언하고 시간이 같을 경우에는 minute을 비교하여 minute에 따라 disable 속성을 판별하고 , 그 후에 예약된 시간과 비교하여 disable 속성을 부여하였습니다.

두 변수 모두 useMemo를 이용하여 의존성 배열 없이 랜더링 될때마다 변수가 선언되지 않도록 한번만 선언되도록 하였습니다.

////////////////////// 수정사항 ////////////////////
지나간 날짜와 시간을 판별하는데 컴포넌트에다가 바로 쓰지 않고 함수하나를 만들어서 그 함수를 넣어주고 인수로 날짜 데이터를 받아왔더니 문제없이 작동 하였습니다. 마찬가지로 랜더링 될때마다 함수가 불려지면 안될거 같아서 useCallback을 활용하여 진행하였습니다.


## :: 질문사항

날짜 관련해서는, 랜더링 될때 함수를 한번만 호출하면 되기때문에, useCallback 의 의존성 배열에 [] 빈 배열을넣어주었는데,timetable 같은경우는 예를들어 13:59분에 날짜를 선택하여 시간을 열고 14:00가 되었을때 화면상의 14:00 버튼이 비활성화가 되어야된다고 생각을 해서, 이같은 경우는 useCallback이 아니라 다른 방식으로 구현해야 하는걸까요?
