### PR TITLE
스케쥴페이지 서버연동

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -6,11 +6,9 @@ import {SafeAreaProvider} from 'react-native-safe-area-context';
 import Entry from '@screens/Entry/Entry';
 import Login from '@screens/Login/Login';
 import Mains from '@components/Mains';
-import Main from '@screens/Main/Main';
 import DocList from '@screens/DocList/DocList';
 import DocScheme from '@screens/DocScheme/DocScheme';
 import MakeREZ from '@screens/MakeREZ/MakeREZ';
-import REZList from '@screens/REZList/REZList';
 import REZDetail from '@screens/REZDetail/REZDetail';
 import REZSubmit from '@screens/REZSubmit/REZSubmit';
 import Signup from '@screens/Signup/Signup';
@@ -57,15 +55,15 @@ function App() {
             <SafeAreaProvider>
               <NavigationContainer>
                 <Stack.Navigator>
-                  {!userState.isLogIn ? (
+                  {userState.isLogIn ? (
                     <>
-                      <Stack.Screen name="DocScheme" component={DocScheme} />
                       <Stack.Screen
                         name="Mains"
                         component={Mains}
                         options={{headerShown: false}}
                       />
                       <Stack.Screen name="DocList" component={DocList} />
+                      <Stack.Screen name="DocScheme" component={DocScheme} />
                       <Stack.Screen name="MakeREZ" component={MakeREZ} />
                       <Stack.Screen
                         name="REZSubmit"

--- a/App.tsx
+++ b/App.tsx
@@ -57,15 +57,15 @@ function App() {
             <SafeAreaProvider>
               <NavigationContainer>
                 <Stack.Navigator>
-                  {userState.isLogIn ? (
+                  {!userState.isLogIn ? (
                     <>
+                      <Stack.Screen name="DocScheme" component={DocScheme} />
                       <Stack.Screen
                         name="Mains"
                         component={Mains}
                         options={{headerShown: false}}
                       />
                       <Stack.Screen name="DocList" component={DocList} />
-                      <Stack.Screen name="DocScheme" component={DocScheme} />
                       <Stack.Screen name="MakeREZ" component={MakeREZ} />
                       <Stack.Screen
                         name="REZSubmit"

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -20,7 +20,7 @@ function Calendar({calendarDate, weeklength, dayoff, today}: CalendarProps) {
         {calendarDate.slice(0, 7).map((date: NewDate, idx: number) => (
           <CalendarButton
             key={idx}
-            isDayOff={isDayValid(date) || dayoff.includes(date.date.toString())}
+            isDayOff={isDayValid(date) || dayoff.includes(date.day)}
             isChecked={selectDate.date !== 0 && date.date === selectDate.date}
             dateInfo={date}>
             {date.date}
@@ -31,7 +31,7 @@ function Calendar({calendarDate, weeklength, dayoff, today}: CalendarProps) {
         {calendarDate.slice(7, 14).map((date: NewDate, idx: number) => (
           <CalendarButton
             key={idx}
-            isDayOff={isDayValid(date) || dayoff.includes(date.date.toString())}
+            isDayOff={isDayValid(date) || dayoff.includes(date.day)}
             isChecked={selectDate.date !== 0 && date.date === selectDate.date}
             dateInfo={date}>
             {date.date}
@@ -42,7 +42,7 @@ function Calendar({calendarDate, weeklength, dayoff, today}: CalendarProps) {
         {calendarDate.slice(14, 21).map((date: NewDate, idx: number) => (
           <CalendarButton
             key={idx}
-            isDayOff={isDayValid(date) || dayoff.includes(date.date.toString())}
+            isDayOff={isDayValid(date) || dayoff.includes(date.day)}
             isChecked={selectDate.date !== 0 && date.date === selectDate.date}
             dateInfo={date}>
             {date.date}
@@ -53,7 +53,7 @@ function Calendar({calendarDate, weeklength, dayoff, today}: CalendarProps) {
         {calendarDate.slice(21, 28).map((date: NewDate, idx: number) => (
           <CalendarButton
             key={idx}
-            isDayOff={isDayValid(date) || dayoff.includes(date.date.toString())}
+            isDayOff={isDayValid(date) || dayoff.includes(date.day)}
             isChecked={selectDate.date !== 0 && date.date === selectDate.date}
             dateInfo={date}>
             {date.date}
@@ -66,9 +66,7 @@ function Calendar({calendarDate, weeklength, dayoff, today}: CalendarProps) {
             {calendarDate.slice(28, 35).map((date: NewDate, idx: number) => (
               <CalendarButton
                 key={idx}
-                isDayOff={
-                  isDayValid(date) || dayoff.includes(date.date.toString())
-                }
+                isDayOff={isDayValid(date) || dayoff.includes(date.day)}
                 isChecked={
                   selectDate.date !== 0 && date.date === selectDate.date
                 }
@@ -82,9 +80,7 @@ function Calendar({calendarDate, weeklength, dayoff, today}: CalendarProps) {
               {calendarDate.slice(35, 42).map((date: NewDate, idx: number) => (
                 <CalendarButton
                   key={idx}
-                  isDayOff={
-                    isDayValid(date) || dayoff.includes(date.date.toString())
-                  }
+                  isDayOff={isDayValid(date) || dayoff.includes(date.day)}
                   isChecked={
                     selectDate.date !== 0 && date.date === selectDate.date
                   }

--- a/src/screens/DocScheme/DocScheme.tsx
+++ b/src/screens/DocScheme/DocScheme.tsx
@@ -33,7 +33,7 @@ function DocScheme({navigation}: DocSchemeNavigationProps) {
     date: TODAY.getDate(),
     day: TODAY.getDay(),
   });
-  const [weeksOff, setWeeksOff] = useState([]);
+  const [weeksOff, setWeeksOff] = useState<number[]>([]);
   const [timeTable, setTimeTable] = useState<TimeTableProp>({
     expired_times: [],
     working_times: {times: []},
@@ -172,6 +172,9 @@ function DocScheme({navigation}: DocSchemeNavigationProps) {
       const timetableHours: number = Number(item.split(':')[0]);
       const timetableMinutes: number = Number(item.split(':')[1]);
       return (
+        selectDate.year === today.year &&
+        selectDate.month === today.month &&
+        selectDate.date === today.date &&
         new Date(
           today.year,
           today.month,
@@ -179,7 +182,13 @@ function DocScheme({navigation}: DocSchemeNavigationProps) {
           timetableHours,
           timetableMinutes,
         ) <=
-        new Date(today.year, today.month, today.date, limitHours, limitMinutes)
+          new Date(
+            today.year,
+            today.month,
+            today.date,
+            limitHours,
+            limitMinutes,
+          )
       );
     },
     [date.month, date.year],
@@ -195,16 +204,9 @@ function DocScheme({navigation}: DocSchemeNavigationProps) {
   const renderItem = ({item}: {item: string}) =>
     item ? (
       <TimeButton
-        disabled={
-          (selectDate.date === today.date && isTimePass(item)) ||
-          isTimeExpired(item)
-        }
+        disabled={isTimePass(item) || isTimeExpired(item)}
         onPress={() => goMakeREZ(item)}>
-        <ButtonText
-          disabled={
-            (selectDate.date === today.date && isTimePass(item)) ||
-            isTimeExpired(item)
-          }>
+        <ButtonText disabled={isTimePass(item) || isTimeExpired(item)}>
           {item}
         </ButtonText>
       </TimeButton>
@@ -238,9 +240,9 @@ function DocScheme({navigation}: DocSchemeNavigationProps) {
           </NextYear>
         </CalendarButtonWrapper>
         <WeekInfo>
-          {DAYS.map((day, idx) => (
+          {DAYS.map((day: string, idx: number) => (
             <WeekButton key={idx}>
-              <WeekText>{day}</WeekText>
+              <WeekText invalid={weeksOff.includes(idx)}>{day}</WeekText>
             </WeekButton>
           ))}
         </WeekInfo>
@@ -336,9 +338,10 @@ const WeekButton = styled.View`
   height: 35px;
 `;
 
-const WeekText = styled.Text`
+const WeekText = styled.Text<{invalid: boolean}>`
   font-size: ${({theme}) => theme.fontRegular};
-  color: ${({theme}) => theme.primary};
+  color: ${({invalid}) =>
+    invalid ? ({theme}) => theme.DOCSchemeCaloff : ({theme}) => theme.primary};
 `;
 
 const TimeTable = styled.View<{isShow: boolean}>`

--- a/src/screens/DocScheme/DocScheme.tsx
+++ b/src/screens/DocScheme/DocScheme.tsx
@@ -14,31 +14,16 @@ import Calendar from '@components/Calendar';
 import Next from '@assets/images/NextIcon.png';
 import Prev from '@assets/images/PrevIcon.png';
 import {SelectContext} from '../../ReservationContext';
+import {config} from '~/src/config';
 
-interface TIMESProp {
-  id: string;
+interface TimeTableProp {
+  expired_times: string[];
+  working_times: {times: string[]};
 }
 const DAYS: string[] = ['일', '월', '화', '수', '목', '금', '토'];
 const TODAY = new Date();
-const DAYOFF: string[] = ['1', '4', '6', '14', '16', '20', '22', '24', '25'];
-const TIMES: TIMESProp[] = [
-  {id: '05:20'},
-  {id: '06:50'},
-  {id: '07:00'},
-  {id: '12:12'},
-  {id: '14:00'},
-  {id: '15:00'},
-  {id: '16:50'},
-  {id: '17:00'},
-  {id: '18:55'},
-  {id: '19:00'},
-  {id: '20:00'},
-  {id: '21:00'},
-  {id: '22:00'},
-  {id: '23:00'},
-];
 
-const FULL: string[] = ['10:00', '11:00', '12:00'];
+const CHANGEWEEKS = [1, 2, 3, 4, 5, 6, 0];
 
 function DocScheme({navigation}: DocSchemeNavigationProps) {
   const [calendarDate, setCalendarDate] = useState<NewDate[]>([]);
@@ -48,6 +33,12 @@ function DocScheme({navigation}: DocSchemeNavigationProps) {
     date: TODAY.getDate(),
     day: TODAY.getDay(),
   });
+  const [weeksOff, setWeeksOff] = useState([]);
+  const [timeTable, setTimeTable] = useState<TimeTableProp>({
+    expired_times: [],
+    working_times: {times: []},
+  });
+
   const {selectDate, setSelectDate} = useContext(SelectContext);
 
   useEffect(() => {
@@ -59,8 +50,33 @@ function DocScheme({navigation}: DocSchemeNavigationProps) {
   }, [navigation]);
 
   useEffect(() => {
+    const nowCalDate: NewDate = getNewDate(new Date(date.year, date.month - 1));
+    fetch(
+      `${config.docScheme}/1?year=${nowCalDate.year}&month=${nowCalDate.month}`,
+    )
+      .then(res => res.json())
+      .then(res =>
+        setWeeksOff(res.result.map((el: number) => CHANGEWEEKS[el])),
+      );
+
     getAlldate();
   }, [date]);
+
+  useEffect(() => {
+    let timer: NodeJS.Timeout;
+    if (selectDate.date !== 0) {
+      timer = setTimeout(() => {
+        fetch(
+          `${config.docScheme}/1?year=${selectDate.year}&month=${selectDate.month}&dates=${selectDate.date}`,
+        )
+          .then(res => res.json())
+          .then(res => setTimeTable(res));
+      }, 600);
+    }
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [selectDate]);
 
   const getNewDate = (newDate: Date): NewDate => {
     const year = newDate.getFullYear();
@@ -149,12 +165,12 @@ function DocScheme({navigation}: DocSchemeNavigationProps) {
     await navigation.navigate('MakeREZ');
   };
 
-  const isTimeValid = useCallback(
-    (item: TIMESProp) => {
+  const isTimePass = useCallback(
+    (item: string) => {
       const limitHours: number = TODAY.getHours() + 1;
       const limitMinutes: number = TODAY.getMinutes();
-      const timetableHours: number = Number(item.id.split(':')[0]);
-      const timetableMinutes: number = Number(item.id.split(':')[1]);
+      const timetableHours: number = Number(item.split(':')[0]);
+      const timetableMinutes: number = Number(item.split(':')[1]);
       return (
         new Date(
           today.year,
@@ -166,23 +182,30 @@ function DocScheme({navigation}: DocSchemeNavigationProps) {
         new Date(today.year, today.month, today.date, limitHours, limitMinutes)
       );
     },
-    [date],
+    [date.month, date.year],
   );
 
-  const renderItem = ({item}: {item: TIMESProp}) =>
-    item.id ? (
+  const isTimeExpired = useCallback(
+    (item: string) =>
+      timeTable.expired_times.length !== 0 &&
+      timeTable.expired_times.includes(item),
+    [timeTable],
+  );
+
+  const renderItem = ({item}: {item: string}) =>
+    item ? (
       <TimeButton
         disabled={
-          (selectDate.date === today.date && isTimeValid(item)) ||
-          FULL.includes(item.id)
+          (selectDate.date === today.date && isTimePass(item)) ||
+          isTimeExpired(item)
         }
-        onPress={() => goMakeREZ(item.id)}>
+        onPress={() => goMakeREZ(item)}>
         <ButtonText
           disabled={
-            (selectDate.date === today.date && isTimeValid(item)) ||
-            FULL.includes(item.id)
+            (selectDate.date === today.date && isTimePass(item)) ||
+            isTimeExpired(item)
           }>
-          {item.id}
+          {item}
         </ButtonText>
       </TimeButton>
     ) : (
@@ -222,7 +245,7 @@ function DocScheme({navigation}: DocSchemeNavigationProps) {
           ))}
         </WeekInfo>
         <Calendar
-          dayoff={DAYOFF}
+          dayoff={weeksOff}
           weeklength={calendarDate.length}
           calendarDate={calendarDate}
           today={today}
@@ -231,10 +254,14 @@ function DocScheme({navigation}: DocSchemeNavigationProps) {
       <TimeTable isShow={selectDate.date !== 0}>
         <TimeButtonWrapper
           renderItem={renderItem}
-          data={TIMES.length % 3 === 2 ? TIMES.concat({id: ''}) : TIMES}
+          data={
+            timeTable.working_times.times.length % 3 === 2
+              ? timeTable.working_times.times.concat('')
+              : timeTable.working_times.times
+          }
           numColumns={3}
           columnWrapperStyle={{justifyContent: 'space-between'}}
-          keyExtractor={(item: TIMESProp, index: number) => index.toString()}
+          keyExtractor={(item: string, index: number) => index.toString()}
         />
         <TimeTableFooter>해당 시간은 현지시간 기준입니다</TimeTableFooter>
       </TimeTable>

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -88,7 +88,7 @@ export interface SelectDateProp {
 export interface CalendarProps {
   calendarDate: NewDate[];
   weeklength: number;
-  dayoff: string[];
+  dayoff: number[];
   today: NewDate;
 }
 


### PR DESCRIPTION
## :: 최근 작업 주제
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
<br />

## :: 구현 목표 
DocScheme 페이지에서 백엔드로부터 데이터를 받아와 화면을 나타내게 하였습니다.

<br />

## :: 세부 내용

연도와 해당 월이 바뀌면서 달력에서 선택된 연도와 월에 해당하는 의사의 쉬는 요일이 백엔드로부터 데이터가 오게되고, 백엔드가 가지고있는 요일데이터 형식(월-일:0,1,2,3,4,5,6)을 프론트에서 사용할 요일 형식(일-토:0,1,2,3,4,5,6)으로 변환하여 값을 저장해서 Calendar 컴포넌트에서 중복되는 요일의 날짜와 달력에서의 해당 요일은 비활성화되도록 하였습니다.

날짜를 선택했을때만 백엔드로부터 working_time 과 expired_time 을 받아와서 working_time 데이터를 이용하여 flatList로 예약가능한 시간 버튼을 만들고, working_time과 expired_time 을 비교하여 중복되는 시간은 선택되지 않도록 구현하였습니다(비교하는 로직은 모두 useCallback 함수로 처리하였습니다)\

## :: 질문사항
백엔드로부터 받아오는 쉬는 요일같은 경우는 Month나 year 값이 변하지 않으면 새로 랜더링 될 필요가 없어, useRef나 useMemo 또는 useCallback같이 의존값에 따라 작동하는 훅을 사용해야 할 것 같은데.. fetch 함수에서 백엔드에서 받아온값을 어떻게 저장해야될지를 못찾아서 일단은 배운대로 state를 활용하였는데... 어떤 방식으로 하는게 가장 효율적인지 궁금합니다.

로직이 너무 복잡하고 길어진거 같은데 추후에 시간이 된다면 최대한 정리해 보도록 하겠습니다...


