### PR TITLE
페이지네이션 통신관련 수정

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -24,18 +24,18 @@ import {
 
 import {ThemeProvider} from 'styled-components';
 import theme from './src/styles/theme';
-import {HomeStackParamList, DocDataProp} from '~/src/types/type';
+import {HomeStackParamList, DocListProp, REZListProp} from '~/src/types/type';
 
 const Stack = createStackNavigator<HomeStackParamList>();
 
 function App() {
   const {userState, loadData} = useContext(AuthContext);
-  const [docInfo, setDocInfo] = useState<DocDataProp>({
+  const [docInfo, setDocInfo] = useState<DocListProp | REZListProp>({
     id: 0,
-    name: '',
-    subject: '',
-    hospital: '',
-    profile_image: '',
+    doctor_name: '',
+    subject_name: '',
+    hospital_name: '',
+    doctor_image: '',
   });
   const [symptomText, setSymptomText] = useState('');
   const [selectImage, setSelectImage] = useState<Asset[]>([]);
@@ -70,7 +70,7 @@ function App() {
                           name="DocScheme"
                           component={DocScheme}
                           options={{
-                            title: docInfo.name,
+                            title: docInfo.doctor_name,
                             headerStyle: {shadowColor: 'white'},
                             headerTitleAlign: 'center',
                           }}
@@ -103,7 +103,11 @@ function App() {
                       </>
                     ) : (
                       <>
-                        <Stack.Screen name="Entry" component={Entry} />
+                        <Stack.Screen
+                          name="Entry"
+                          component={Entry}
+                          options={{headerShown: false}}
+                        />
                         <Stack.Screen name="Login" component={Login} />
                         <Stack.Screen
                           name="Signup"

--- a/src/ReservationContext.tsx
+++ b/src/ReservationContext.tsx
@@ -1,19 +1,19 @@
 import React, {createContext, Dispatch, SetStateAction} from 'react';
 import {Asset} from 'react-native-image-picker';
-import {DocDataProp} from '~/src/types/type';
+import {DocListProp, REZListProp} from '~/src/types/type';
 
 interface DocInfoProps {
-  docInfo: DocDataProp;
-  setDocInfo: React.Dispatch<React.SetStateAction<DocDataProp>>;
+  docInfo: DocListProp | REZListProp;
+  setDocInfo: React.Dispatch<React.SetStateAction<DocListProp | REZListProp>>;
 }
 
 export const DocInfoContext = createContext<DocInfoProps>({
   docInfo: {
     id: 0,
-    name: '',
-    subject: '',
-    hospital: '',
-    profile_image: '',
+    doctor_name: '',
+    subject_name: '',
+    hospital_name: '',
+    doctor_image: '',
   },
   setDocInfo: () => {},
 });

--- a/src/components/DoctorCard.tsx
+++ b/src/components/DoctorCard.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import styled from 'styled-components/native';
-import {DocDataProp} from '~/src/types/type';
+import {DocListProp, REZListProp} from '~/src/types/type';
 
-function DoctorCard({docData}: {docData: DocDataProp}) {
+function DoctorCard({docData}: {docData: DocListProp | REZListProp}) {
   return (
     <Card>
-      <DoctorImg source={{uri: docData.profile_image}}></DoctorImg>
+      <DoctorImg source={{uri: docData.doctor_image}}></DoctorImg>
       <DoctorInfoWrapper>
-        <DoctorName>{docData.name} 선생님</DoctorName>
+        <DoctorName>{docData.doctor_name} 선생님</DoctorName>
         <CategoryInfo>
-          <Category>{docData.subject} 전문의</Category>
-          <Hospital>{docData.hospital}</Hospital>
+          <Category>{docData.subject_name} 전문의</Category>
+          <Hospital>{docData.hospital_name}</Hospital>
         </CategoryInfo>
       </DoctorInfoWrapper>
     </Card>

--- a/src/components/usePagination.tsx
+++ b/src/components/usePagination.tsx
@@ -17,7 +17,6 @@ function usePagination(renderItemNum: number) {
       );
       if (response.status === 200) {
         const result = await response.json();
-        console.log(result);
         setPaginationItem(paginationItem.concat(result.result));
       }
     };
@@ -26,22 +25,18 @@ function usePagination(renderItemNum: number) {
   }, []);
 
   const addList = async () => {
-    console.log('hi');
     pageNum.current++;
 
-    console.log(pageNum.current);
     const response = await fetch(
       `${config.docList}/list?page=${pageNum.current}&limit=${renderItemNum}`,
       {
         headers: {Authorization: await getToken()},
       },
     );
-    console.log(response);
     if (response.status === 200) {
       const result = await response.json();
       setPaginationItem(paginationItem.concat(result.result));
     }
-    console.log(paginationItem);
   };
   return {
     paginationItem,

--- a/src/components/usePagination.tsx
+++ b/src/components/usePagination.tsx
@@ -1,24 +1,47 @@
-import {useState, useRef} from 'react';
+import {useState, useRef, useEffect} from 'react';
+import {config} from '../config';
+import {getToken} from '../AuthContext';
 
-function usePagination<T>(
-  renderItemNum: number,
-  paginationItem: T[],
-): {paginationItem: T[]; addList: () => void} {
-  const [renderItem, setRenderItem] = useState(
-    paginationItem.slice(0, renderItemNum),
-  );
+function usePagination(renderItemNum: number) {
+  const [paginationItem, setPaginationItem] = useState([]);
 
-  const pageNum = useRef(0);
+  const pageNum = useRef(1);
 
-  const addList = () => {
-    const limit = 5;
+  useEffect(() => {
+    const fetchData = async () => {
+      const response = await fetch(
+        `${config.docList}/list?page=1&limit=${renderItemNum}`,
+        {
+          headers: {Authorization: await getToken()},
+        },
+      );
+      if (response.status === 200) {
+        const result = await response.json();
+        console.log(result);
+        setPaginationItem(paginationItem.concat(result.result));
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  const addList = async () => {
+    console.log('hi');
     pageNum.current++;
-    let offset =
-      pageNum.current === 1
-        ? renderItemNum
-        : renderItemNum + (pageNum.current - 1) * limit;
-    const additionalDocData = paginationItem.slice(offset, offset + limit);
-    setRenderItem(renderItem.concat(additionalDocData));
+
+    console.log(pageNum.current);
+    const response = await fetch(
+      `${config.docList}/list?page=${pageNum.current}&limit=${renderItemNum}`,
+      {
+        headers: {Authorization: await getToken()},
+      },
+    );
+    console.log(response);
+    if (response.status === 200) {
+      const result = await response.json();
+      setPaginationItem(paginationItem.concat(result.result));
+    }
+    console.log(paginationItem);
   };
   return {
     paginationItem,

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,4 +8,5 @@ export const config = {
   mains: `${BASE_URL}/reservations/subject`,
   docScheme: `${BASE_URL}/reservations/time`,
   detail: `${BASE_URL}/reservations`,
+  docList: `${BASE_URL}/reservations`,
 };

--- a/src/screens/DocList/DocList.tsx
+++ b/src/screens/DocList/DocList.tsx
@@ -35,8 +35,6 @@ function DocList({navigation, route}: DocListNavigationProps) {
     );
   }
 
-  console.log(paginationItem);
-
   return (
     <DocListWrapper
       data={paginationItem}

--- a/src/screens/DocList/DocList.tsx
+++ b/src/screens/DocList/DocList.tsx
@@ -1,22 +1,10 @@
 import React, {useContext, useEffect} from 'react';
 import styled from 'styled-components/native';
 import {Dimensions, FlatList} from 'react-native';
-import {DocListNavigationProps, DocDataProp} from '~/src/types/type';
+import {DocListNavigationProps, DocListProp} from '~/src/types/type';
 import DoctorCard from '@components/DoctorCard';
 import {DocInfoContext} from '~/src/ReservationContext';
 import usePagination from '@components/usePagination';
-
-const DATA: DocDataProp[] = [];
-for (let i = 0; i < 100; i++) {
-  DATA.push({
-    id: i,
-    name: '의사' + i,
-    subject: 'COVID-19',
-    hospital: '병원1',
-    profile_image:
-      '192.168.0.114:8000/media/doctors_profile_images/default.png',
-  });
-}
 
 const deviceHeight: number = Dimensions.get('window').height;
 
@@ -32,23 +20,22 @@ function DocList({navigation, route}: DocListNavigationProps) {
 
   const {setDocInfo} = useContext(DocInfoContext);
 
-  const {paginationItem, addList} = usePagination<DocDataProp>(
-    renderItemNum,
-    DATA,
-  );
+  const {paginationItem, addList} = usePagination(renderItemNum);
 
-  const goDocScheme = (docInfo: DocDataProp) => {
+  const goDocScheme = (docInfo: DocListProp) => {
     setDocInfo(docInfo);
     navigation.navigate('DocScheme');
   };
 
-  function renderItem({item}: {item: DocDataProp}): JSX.Element {
+  function renderItem({item}: {item: DocListProp}): JSX.Element {
     return (
       <ListButton onPress={() => goDocScheme(item)}>
         <DoctorCard docData={item}></DoctorCard>
       </ListButton>
     );
   }
+
+  console.log(paginationItem);
 
   return (
     <DocListWrapper

--- a/src/screens/REZList/REZList.tsx
+++ b/src/screens/REZList/REZList.tsx
@@ -1,54 +1,39 @@
 import React, {useEffect, useContext} from 'react';
 import {Dimensions, FlatList} from 'react-native';
 import styled from 'styled-components/native';
-import {REZListNavigationProps, DocDataProp} from '~/src/types/type';
+import {REZListNavigationProps, REZListProp} from '~/src/types/type';
 import DoctorCard from '@components/DoctorCard';
 import CalendarImage from '@assets/images/calendar_icon.png';
 import {DocInfoContext} from '~/src/ReservationContext';
 import Status from '~/src/components/Status';
 import usePagination from '~/src/components/usePagination';
 
-const DATA: DocDataProp[] = [];
-for (let i = 0; i < 100; i++) {
-  DATA.push({
-    id: i,
-    name: '의사' + i,
-    subject: 'COVID-19',
-    hospital: '병원1',
-    profile_image:
-      '192.168.0.114:8000/media/doctors_profile_images/default.png',
-  });
-}
-
 const deviceHeight: number = Dimensions.get('window').height;
 
-const renderItemNum: number = Math.floor(deviceHeight / 125);
+const renderItemNum: number = Math.floor(deviceHeight / 150);
 
 function REZList({navigation}: REZListNavigationProps) {
   const {setDocInfo} = useContext(DocInfoContext);
 
-  const {paginationItem, addList} = usePagination<DocDataProp>(
-    renderItemNum,
-    DATA,
-  );
+  const {paginationItem, addList} = usePagination(renderItemNum);
 
   useEffect(() => {
     navigation.setOptions({title: '예약 목록', headerShadowVisible: false});
   });
 
-  const goDocScheme = (docInfo: DocDataProp) => {
+  const goREZDetail = (docInfo: REZListProp) => {
     setDocInfo(docInfo);
     navigation.navigate('REZDetail');
   };
 
-  const renderItem = ({item}: {item: DocDataProp}) => (
-    <ListButton onPress={() => goDocScheme(item)}>
+  const renderItem = ({item}: {item: REZListProp}) => (
+    <ListButton onPress={() => goREZDetail(item)}>
       <ListHeader>
         <DateWrapper>
           <CalendarIcon source={CalendarImage} resizeMode="contain" />
-          <DateText>2020-07-24(금) 오후 3:00</DateText>
+          <DateText>{`${item.date} ${item.time}`}</DateText>
         </DateWrapper>
-        <Status>진료대기</Status>
+        <Status>{item.status_name}</Status>
       </ListHeader>
       <DoctorCard docData={item}></DoctorCard>
     </ListButton>

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -80,12 +80,23 @@ export type DocListNavigationProps = StackScreenProps<
   'DocList'
 >;
 
-export interface DocDataProp {
+export interface DocListProp {
   id: number;
-  name: string;
-  subject: string;
-  hospital: string;
-  profile_image: string;
+  doctor_name: string;
+  subject_name: string;
+  hospital_name: string;
+  doctor_image: string;
+}
+
+export interface REZListProp {
+  doctor_image: string;
+  doctor_name: string;
+  hospital_name: string;
+  date: string;
+  reservation_id: number;
+  status_name: string;
+  subject_name: string;
+  time: string;
 }
 
 export type DocSchemeNavigationProps = StackScreenProps<


### PR DESCRIPTION
## :: 최근 작업 주제
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
<br />

## :: 구현 목표 

예약리스트 관련 페이지네이션 서버연동

<br />

## :: 세부 내용

1. 서버에서 데이터를 받아온 후 그 데이터를 이용하여 리스트페이지를 생성하였습니다.
2. 기존의 목데이터를 지우고 usepagination 커스텀훅에서 effect로 처음 데이터를 받아온 후 리스트가 맨 아래목록에 도달하면 addList함수가 작동되면서 addList함수안에서 fetch를 통해서 추가데이터를 받아오게되고, 그 데이터를 스테이트에 저장하여 리스트가 추가되도록 구현하였습니다.
3. 페이지네이션훅에서 페이지를 설정하고 함수가 작동할때 페이지를 하나씩 올리면서 페이지number와 처음 받아온 limit 를 이용하여 fetch를 받아오도록 하였습니다.